### PR TITLE
Add `csv` to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ group :test do
 end
 
 gem 'rake', '~> 13.0'
+
+gem "csv", "~> 3.3"


### PR DESCRIPTION
`csv` was removed as a [default gems in Ruby 3.4.0](https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/), and now needs to be explicitly added as a dependency.

All tests pass on Ruby 4.0.2:

```
% ruby -v
ruby 4.0.2 (2026-03-17 revision d3da9fec82) +PRISM [arm64-darwin20]

% REMOTE_TESTS=true bundle exec rake test
[...]
--------------------------------------------------------------------------------------------------------------------------------------
161 tests, 818 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------
```